### PR TITLE
disable annual leave being added when members worked exceeded

### DIFF
--- a/public/template/statistics/directives/yearlyDir.html
+++ b/public/template/statistics/directives/yearlyDir.html
@@ -40,7 +40,7 @@
           </td>
           <td>
             <span class="f-12px lh-17px h-18">
-                  {{getAnnualLeave(workers.id, yearWork, workers.nationality, workers.enterDate)}}
+                  {{getAnnualLeave(workers.id, workers.nationality, workers.enterDate, workers.workedData)}}
             </span>
           </td>
           <td>


### PR DESCRIPTION
- **Before**: when members worked and it exceeds to the current month needed.

  the extra work will be added to annual leave.

- **Now**: annual leave will only be added when month duration has increase.